### PR TITLE
remove workaround for limitations on http gem

### DIFF
--- a/lib/mongo_http_sync/parser.rb
+++ b/lib/mongo_http_sync/parser.rb
@@ -4,7 +4,7 @@ module MongoHTTPSync
   class Parser
     def self.parse(io, &block)
       handler = Handler.new(block)
-      Oj.sc_parse(handler, ReadpartialWorkaround.new(io))
+      Oj.sc_parse(handler, io)
       handler.ndocs
     end
     class Handler < ::Oj::ScHandler
@@ -44,24 +44,6 @@ module MongoHTTPSync
 
       def error(message, line, column)
         throw "#{message} (line: #{line}, column: #{column})"
-      end
-    end
-    class ReadpartialWorkaround
-      def initialize(target)
-        @target = target
-      end
-      def readpartial(maxlen)
-        if @buffer and @buffer.length > 0
-          buff = @buffer[0..maxlen-1]
-          @buffer = @buffer[maxlen..-1]
-          return buff
-        end
-        r = @target.readpartial(maxlen)
-        if r.dup.bytesize > maxlen
-          @buffer = r[maxlen..-1]
-          r = r[0..maxlen-1]
-        end
-        r
       end
     end
   end

--- a/mongo_http_sync.gemspec
+++ b/mongo_http_sync.gemspec
@@ -21,14 +21,13 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.13"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "pry"
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rspec"
   spec.add_development_dependency "guard-rspec"
   spec.add_development_dependency "webmock"
   spec.add_dependency "mongoid"
   spec.add_dependency "oj"
-  spec.add_dependency "http"
+  spec.add_dependency "http", '>= 4.0.0'
   spec.add_dependency "grape-entity"
 end

--- a/spec/support/mongo_http_sync/importer_spec_group.rb
+++ b/spec/support/mongo_http_sync/importer_spec_group.rb
@@ -1,6 +1,5 @@
 require 'webmock/rspec'
 require 'mongo'
-
 RSpec.shared_examples 'an importer' do |importer, collection_name|
   let(:people) { $client[collection_name] }
   describe '#import' do


### PR DESCRIPTION
Removes a workaround created by limitations on the http gem before version 4.0.0 and adds this version as a dependency.